### PR TITLE
Only allow bootstrap_layout_builder 1-4 column layouts

### DIFF
--- a/config/install/core.entity_view_display.node.landing_page_lb.default.yml
+++ b/config/install/core.entity_view_display.node.landing_page_lb.default.yml
@@ -50,7 +50,11 @@ third_party_settings:
   layout_builder_restrictions:
     allowed_block_categories: {  }
     entity_view_mode_restriction:
-      allowed_layouts: {  }
+      allowed_layouts:
+        - 'bootstrap_layout_builder:blb_col_1'
+        - 'bootstrap_layout_builder:blb_col_2'
+        - 'bootstrap_layout_builder:blb_col_3'
+        - 'bootstrap_layout_builder:blb_col_4'
       denylisted_blocks:
         'Inline blocks':
           - 'inline_block:basic_block'


### PR DESCRIPTION
![Edit_layout_for_Landing_Page__Layout_Builder__content_items___Drush_Site-Install](https://user-images.githubusercontent.com/238201/201728999-ec3ba513-12a4-470b-865e-70a704f7316e.png)

Cleans up the "Choose a layout" section